### PR TITLE
Add owasp rules within config

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -15,6 +15,7 @@ controller:
 
   config:
     enable-modsecurity: "true"
+    enable-owasp-modsecurity-crs: "true"
     custom-http-errors: 413,502,503,504
     generate-request-id: "true"
     proxy-buffer-size: "16k"


### PR DESCRIPTION
WHAT 
Add owasp rules to configmap

WHY
This will load owasp rules for teams to use with ingresses. Teams will not need (or be allowed) to load owasp rules manually as this replicates the same rules and overloads nginx. 