### PR TITLE
Remove metrics endpoint for defaultBackend

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -137,7 +137,7 @@ defaultBackend:
   enabled: true
   image:
     repository: ministryofjustice/cloud-platform-custom-error-pages
-    tag: "0.4"
+    tag: "0.5"
 
 rbac:
   create: true


### PR DESCRIPTION
As metrics from the Custom Error Page is not used and are important. This will fix the concern raised by security.