### PR TITLE
Bump custom error page image to 0.6

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -137,7 +137,7 @@ defaultBackend:
   enabled: true
   image:
     repository: ministryofjustice/cloud-platform-custom-error-pages
-    tag: "0.5"
+    tag: "0.6"
 
 rbac:
   create: true


### PR DESCRIPTION
Closes: https://github.com/ministryofjustice/cloud-platform/issues/3192