### PR TITLE
update-pin-helm-version-in-modules

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,6 +3,7 @@ terraform {
   required_providers {
     helm = {
       source = "hashicorp/helm"
+      version = "~> 2.6.0"
     }
   }
 }


### PR DESCRIPTION
Why: 
[upgrade & pin Helm provider for Infrastructure#3882](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3882)